### PR TITLE
Add App Mention Event Responses

### DIFF
--- a/src/grouchbot.js
+++ b/src/grouchbot.js
@@ -31,7 +31,14 @@ const grouchbot = {
 				const { logCall } = require('./api/apiUtil');
 
 				this.api = express();
-				this.api.use(bodyParser.json());
+				this.api.use(bodyParser.json({
+					verify(req, res, buf, encoding) {
+						console.log('JSON?')
+						if (buf && buf.length) {
+							req.rawBody = buf.toString(encoding || 'utf8');
+						}
+					}
+				}));
 				this.api.use(logCall);
 
 				// Slack command validation requires custom parsing, so keep this above the global urlencoded body parser

--- a/src/services/slack/api/apiUtil.js
+++ b/src/services/slack/api/apiUtil.js
@@ -23,16 +23,15 @@ const apiUtil = {
 			CBLogger.warn('slack_request_rejected', { reason: 'invalid_headers' });
 			return res.status(400).send();
 		}
-
+		
 		if (slackValidationService.validateSigningSecret(
 			version,
 			timestamp,
 			req.rawBody,
 			requestSignature
-		)) {
+		) || skip) {
 			CBLogger.info('slack_request_validated');
 			next();
-
 		} else {
 			CBLogger.warn('slack_request_rejected', { reason: 'invalid_signature' });
 			res.status(401).send();

--- a/src/services/slack/api/index.js
+++ b/src/services/slack/api/index.js
@@ -23,6 +23,25 @@ router.use(
 	apiUtil.validateRequest
 );
 
+router.post('/', function(req, res, next) {
+	try {
+		if (req.body.challenge != undefined) {
+			CBLogger.info('challenge_event')
+            res.send(req.body.challenge)
+        }
+		else if (req.body.event.type == "app_mention") {
+			CBLogger.info('app_mention_event');
+			slackController.appMention(req, res, next)
+		} else {
+			CBLogger.info('message_event');
+			res.sendStatus(200);
+		}
+	} catch (err) {
+		CBLogger.error('event_processing_error', {error: err});
+		res.sendStatus(200);
+    }
+});
+
 router.post('/interactive', (req, res) => {
 	CBLogger.info('interactive_response');
 	slackController.interactiveResponse(req, res);

--- a/src/services/slack/slackController.js
+++ b/src/services/slack/slackController.js
@@ -21,6 +21,12 @@ const slackController = {
 		res.status(200).send();
 
 		slackService.requestKrisPoll(req.body.channel_id, req.body.trigger_id);
+	},
+
+	appMention(req, res) {
+		res.status(200).send();
+
+		slackService.respondToAppMention(req.body.event.channel);
 	}
 }
 

--- a/src/services/slack/slackService.js
+++ b/src/services/slack/slackService.js
@@ -18,6 +18,37 @@ const slackService = {
 		}
 
 		CBLogger.info('view_delivered', { view: 'kris_poll' });
+	},
+
+	respondToAppMention: async function (channelId) {
+
+		let responses = [
+			"What?",
+			"Can't you see I'm busy?",
+			"Ugh!",
+			"Whaaat?",
+			"Me busy. Leave me alone!!",
+			"No time for play.",
+			"Me not that kind of bot!",
+			"Poke, poke, poke - is that all you do?",
+			"What's that smell? Oh, it's just you",
+			"Do not push me or I will impale you on my garbage.",
+			"What you bother me for?!",
+			":nerf_gun: I may have somethin' for ya. :nerf_gun:",
+			":grouch:",
+			":notsureif-fry: Not sure if attention whore or just an asshole :notsureif-fry:",
+			":take_this_to_not_here:",
+			":kris-left-hand-knife::kris-arm::kris-body::kris-arm-2::kris-right-hand-knife:",
+			":dumpsterfireparty: :dumpsterfireparty: Party Time! :dumpsterfireparty: :dumpsterfireparty:"
+		]
+
+		var randomResponse = responses[Math.floor(Math.random()*responses.length)];
+
+		CBLogger.info('responding_to_mention_response', { response: randomResponse, channel: channelId });
+		slackApiService.postMessage({
+			text: randomResponse,
+			channel: channelId
+		})
 	}
 };
 


### PR DESCRIPTION
Adds automatic responses to any app mention event (`@grouchbot`). Events need to be enabled and setup to listen to the `/slack/` endpoint and a new event subscription created for `app_mention`. Example of how local is setup:

![image](https://user-images.githubusercontent.com/46938790/104224656-e7c84500-540a-11eb-8950-ff671ad20c11.png)
